### PR TITLE
Remove name passed to define(), let the caller name it.

### DIFF
--- a/fast-list.js
+++ b/fast-list.js
@@ -138,7 +138,7 @@ FastList.prototype =
 
 if ("undefined" !== typeof(exports)) module.exports = FastList
 else if ("function" === typeof(define) && define.amd) {
-  define("FastList", function() { return FastList })
+  define(function() { return FastList })
 } else (function () { return this })().FastList = FastList
 
 })()


### PR DESCRIPTION
Would not work as-is anyway since the name did not match the file name. But best practice is to use anonymous modules.
